### PR TITLE
CDE switched from Gitpod to GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "webfreak.debug",
+                "yzhang.markdown-all-in-one", 
+                "bierner.markdown-mermaid", 
+                "houkanshan.vscode-markdown-footnote"
+            ]
+        }
+    }
+}

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,0 @@
-vscode:
-  extensions:
-    - webfreak.debug
-    - yzhang.markdown-all-in-one
-    - bierner.markdown-mermaid
-    - houkanshan.vscode-markdown-footnote
-    

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- blank line kept intentionally -->
 # material-modern-cpp
 This repository hosts the material of the course `Modern C++` 
 
@@ -7,15 +8,4 @@ The structure of the repo is the following:
 - folder `exercises` contains all the material which is used as a support for the lesson;
 - folder `program` is a brief of what the course contains each year.
 
-
-
-This repository can be used with [gitpod](https://www.gitpod.io/docs/introduction/getting-started) and is already configured to use CMake, gcc, gdb and Visual Studio Code to execute the exercises.
-
-Here some gitpod prerequisites:
-> **Warning**
-> 
-> Visit your [Gitpod Integrations](https://gitpod.io/integrations) and make sure that all GitHub permissions are enabled (click on the ellipsis).
->
->  **Note**
->  
-> If you didn't install the gitpod browser extension, visit your [Gitpod Workspaces](https://gitpod.io/workspaces) and click on the green button to create a new workspace by providing the URL of this repository.
+This repository can be used with [GitHub Codespaces](https://docs.github.com/en/codespaces/overview) and is already configured to use CMake, gcc, gdb and Visual Studio Code to execute the exercises.


### PR DESCRIPTION
Gitpod will be very soon undergoing a deep overhaul that will make it no longer our preferred Cloud Development Environment (CDE).

At the same time, GitHub Codespaces are now ripe enough to take it over.

This PR proposes thus the change.

I will provide you guidelines on how to use Codespaces inside this specific organization, @marcoaccame @Nicogene.